### PR TITLE
Fix typo in tutorial

### DIFF
--- a/account-creation-in-ae-cli.md
+++ b/account-creation-in-ae-cli.md
@@ -58,8 +58,8 @@ aecli account create <name> [options]
 - Тhe option capabilities of the command are the following:
 ```
 Options:
-  -u, --url [hostname]                               Node to connect to (default: "https://sdk-mainnet.aepp.com")
-  -U, --internalUrl [internal]                       Node to connect to(internal) (default: "https://sdk-mainnet.aepp.com")
+  -u, --url [hostname]                               Node to connect to (default: "https://sdk-mainnet.aepps.com")
+  -U, --internalUrl [internal]                       Node to connect to(internal) (default: "https://sdk-mainnet.aepps.com")
   --native                                           Build transaction natively
   --networkId [networkId]                            Network ID (default: ae_mainnet)
   -P, --password [password]                          Wallet Password

--- a/smart-contract-deployment-in-forgae.md
+++ b/smart-contract-deployment-in-forgae.md
@@ -83,12 +83,12 @@ The **deploy** command helps developers run their deployment scripts for their Ã
 forgae deploy [path] [network] [secretKey]
 ```
 - **-path** - path to a deployment file, default value is ```./deployment/deploy.js```
-- **-network** (**-n**) - specify the url to a node in this network (ex. https://sdk-mainnet.aepp.com)
+- **-network** (**-n**) - specify the url to a node in this network (ex. https://sdk-mainnet.aepps.com)
 - **-secretKey** (**-s**) - secret(private) key that will unlock the wallet that will be used to deploy the contract
 
 Deploy ExampleContract.aes on mainnet with the following command: 
 ```
-forgae deploy -n https://sdk-mainnet.aepp.com  -s <secretKey>
+forgae deploy -n https://sdk-mainnet.aepps.com  -s <secretKey>
 ```
 
 ## Deploying ExampleContract on the sdk-edgenet


### PR DESCRIPTION
Fixing typos in tutorials.

Mistaken mainnet url: https://sdk-mainnet.aepp.com -> https://sdk-mainnet.aepps.com