### PR TITLE
Updating "TUTORIAL: How to Get Testnet Funds?"

### DIFF
--- a/get-testnet-tokens.md
+++ b/get-testnet-tokens.md
@@ -70,16 +70,25 @@ Getting wallet balance:
 aecli account balance <wallet_path>
 ```
 ```
+Usage: aecli-account [options] [command]
+
 Options:
-  -u, --url [hostname]                               Node to connect to (default: "https://sdk-mainnet.aepps.com")
-  -U, --internalUrl [internal]                       Node to connect to(internal) (default: "https://sdk-mainnet.aepps.com")
-  --native                                           Build transaction natively
-  --networkId [networkId]                            Network id (default: ae_mainnet)
-  -P, --password [password]                          Wallet Password
-  -n, --nonce [nonce]                                Override the nonce that the transaction is going to be sent with
-  -f --force                                         Ignore epoch version compatibility check
-  --json                                             Print result in json format
-  -h, --help                                         output usage information
+  -u, --url [hostname]                                      Node to connect to (default: "https://sdk-mainnet.aepps.com")
+  -U, --internalUrl [internal]                              Node to connect to(internal) (default: "https://sdk-mainnet.aepps.com")
+  -P, --password [password]                                 Wallet Password
+  -f --force                                                Ignore epoch version compatibility check
+  --json                                                    Print result in json format
+  -h, --help                                                output usage information
+
+Commands:
+  spend [options] <wallet_path> <receiver> <amount>
+  transfer [options] <wallet_path> <receiver> <percentage>
+  sign [options] <wallet_path> <tx>                         Create a transaction to another wallet
+  balance [options] <wallet_path>                           Get wallet balance
+  address [options] <wallet_path>                           Get wallet address
+  create [options] <name>                                   Create a secure wallet
+  save [options] <name> <privkey>                           Save a private keys string to a password protected file wallet
+  nonce <wallet_path>                                       Get account nonce
 ```
 When checking the balance of an empty wallet, the expected output should be:
 ```

--- a/get-testnet-tokens.md
+++ b/get-testnet-tokens.md
@@ -83,14 +83,14 @@ Options:
 ```
 When checking the balance of an empty wallet, the expected output should be:
 ```
-aecli account balance ./my-ae-wallet -u https://sdk-edgenet.aepps.com
+aecli account balance ./my-ae-wallet -u https://sdk-testnet.aepps.com
 prompt: Enter your password:  *****
 
 API ERROR: Account not found
 ```
 The account is not found, because the wallet actually has 0 funds and the balance is equal to 0.
 
-Running the above command, but with ```-u https://sdk-edgenet.aepps.com``` will result in the same error.
+Running the above command, but with ```-u https://sdk-testnet.aepps.com``` will result in the same error.
 
 Let's change that!
 ## Getting tokens
@@ -99,7 +99,7 @@ There are two ways of getting tokens. The faucets operated by the SDK team will 
 - sdk-testnet - https://faucet.aepps.com/
 - sdk-edgenet - https://edge-faucet.aepps.com/
 
-In the next steps we're going to show you how to get tokens from the faucet for **sdk-edgenet**. The same proces could be followed for the **sdk-testnet**.
+In the next steps we're going to show you how to get tokens from the faucet for **sdk-testnet**. The same proces could be followed for the **sdk-edgenet**.
 ![][faucet_initial_img]
 *<center>Initial dialog</center>*
 
@@ -122,9 +122,9 @@ Transaction: th_Si4dGBD27P8zJQXEAig68nbzwouk9GZf5DGvEN9JBWjrJdQLb
 
 Account: ak_maudCMZW7WyPrHFhpJNzjBtNBw62L7jceMyqkXkYVXtVfcDK1
 ```
-Finally, let's check the balance of wallet on **sdk-edgenet**:
+Finally, let's check the balance of wallet on **sdk-testnet**:
 ```
-aecli account balance ./my-ae-wallet -u https://sdk-edgenet.aepps.com
+aecli account balance ./my-ae-wallet -u https://sdk-testnet.aepps.com
 ```
 and we have it:
 ```

--- a/get-testnet-tokens.md
+++ b/get-testnet-tokens.md
@@ -10,21 +10,23 @@ The æternity SDK team currently runs three testnets - **sdk-testnet**, **sdk-ed
 
 In the previous tutorial we've installed **aecli**. So we can use ```aecli chain``` to interact with the blockchain. You can see additional information for the command here:
 ```
+Usage: aecli-chain [options] [command]
+
 Options:
-  -u --url [hostname]         Node to connect to (default: "https://sdk-mainnet.aepps.com")
-  --internalUrl [internal]    Node to connect to(internal) (default: "https://sdk-mainnet.aepps.com")
-  --networkId [networkId]     Network id (default: ae_mainnet)
-  -L --limit [playlimit]      Limit for play command (default: 10)
-  -P --height [playToHeight]  Play to selected height
-  -f --force                  Ignore epoch version compatibility check
-  --json                      Print result in json format
-  -h, --help                  output usage information
+  -u --url [hostname]       Node to connect to (default: "https://sdk-mainnet.aepps.com")
+  --internalUrl [internal]  Node to connect to(internal) (default: "https://sdk-mainnet.aepps.com")
+  -L --limit [playlimit]    Limit for play command (default: 10)
+  -f --force                Ignore node version compatibility check
+  --json                    Print result in json format
+  -h, --help                output usage information
 
 Commands:
-  top                         Get top of Chain
-  status                      Get Epoch version
-  mempool                     Get mempool of Chain
-  play                        Real-time block monitoring
+  top                       Get top of Chain
+  status                    Get node version
+  ttl <absoluteTtl>         Get relative ttl
+  network_id                Get network ID
+  play [options]            Real-time block monitoring
+  broadcast [options] <tx>  Send transaction to the chain
 ```
 
 ### sdk-testnet
@@ -36,7 +38,16 @@ aecli chain status -u https://sdk-testnet.aepps.com
 ```
 expected output at the time of writing:
 ```
-Epoch node version____________  0.25.0
+Difficulty______________________________ 151080097
+Node version____________________________ 3.3.0
+Node revision___________________________ f7b59566e1dc12f48db2b5fb76f4a496e782cff9
+Genesis hash____________________________ kh_wUCideEB8aDtUaiHCtKcfywU6oHZW6gnyci8Mw6S1RSTCnCRu
+Network ID______________________________ ae_uat
+Listening_______________________________ true
+Peer count______________________________ 8136
+Pending transactions count______________ 0
+Solutions_______________________________ 0
+Syncing_________________________________ false
 ```
 ### sdk-edgenet
 Audience – people developing the SDKs, developers who need the latest features from the develop branch on github. This network is used primarily for development and can be reset without notification.
@@ -99,17 +110,17 @@ aecli account address my-ae-wallet
 ```
 The CLI will prompt you to type in your password and will give you the following output:
 ```
-Your address is: ak_2EdPu7gJTMZSdFntHK5864CnsRykW1GUwLGC2KeC8tjNnFBjBx
+Your address is: ak_maudCMZW7WyPrHFhpJNzjBtNBw62L7jceMyqkXkYVXtVfcDK1
 ```
 We are placing a request and just few seconds later, our account is topped up:
 ```
-Added 250000000000000000000 AET!
+Added 5 AE!
 
-Current Balance: 250000000000000000000
+Current Balance: 5 AE
 
-Transaction: [th_24L8sJY3d2Gqqd6CTnhmCKU6Ys8AyQ7HCE8q7qouDyypzoJ3aB](https://explorer.aepps.com/#/tx/th_24L8sJY3d2Gqqd6CTnhmCKU6Ys8AyQ7HCE8q7qouDyypzoJ3aB)
+Transaction: th_Si4dGBD27P8zJQXEAig68nbzwouk9GZf5DGvEN9JBWjrJdQLb
 
-Account: ak_2EdPu7gJTMZSdFntHK5864CnsRykW1GUwLGC2KeC8tjNnFBjBx
+Account: ak_maudCMZW7WyPrHFhpJNzjBtNBw62L7jceMyqkXkYVXtVfcDK1
 ```
 Finally, let's check the balance of wallet on **sdk-edgenet**:
 ```
@@ -117,7 +128,9 @@ aecli account balance ./my-ae-wallet -u https://sdk-edgenet.aepps.com
 ```
 and we have it:
 ```
-Your balance is: 250000000000000000000
+Balance_________________________________ 5000000000000000000
+ID______________________________________ ak_maudCMZW7WyPrHFhpJNzjBtNBw62L7jceMyqkXkYVXtVfcDK1
+Nonce___________________________________ 1
 ```
 ### Mining
 If you want to use your node to mine, please read the following documentation:

--- a/get-testnet-tokens.md
+++ b/get-testnet-tokens.md
@@ -1,12 +1,12 @@
 # TUTORIAL: How to Get Testnet Funds?
 ## Tutorial Overview
-In this tutorial we'll briefly explain æternity testnets – what they are, what they're used for, and how to get AE tokens from a faucet for testnets.
+In this tutorial we'll briefly explain the æternity testnet – what they are, what they're used for, and how to get AE tokens from a faucet for the testnet.
 ## Prerequisites
 - Please read our previous tutorial [How to Create an æternity Account With CLI?](account-creation-in-ae-cli.md) in order to better understand the next steps and to follow them.
-## æternity test networks
-Testnets are copies of the æternity blockchain almost identical to the live network except the fact that their AE tokens are worthless.
+## æternity test network
+The testnet of the æternity blockchain is almost identical to the live network except the fact that their AE tokens are worthless.
 
-The æternity SDK team currently runs three testnets - **sdk-testnet**, **sdk-edgenet** and **uat-testnet**. Testnet is the latest stable release, and Edgenet is the next. The æternity core team runs another network, **uat-testnet**. It’s for internal testing and is not guaranteed to work with the SDKs. But it’s the one which has the very latest features and may be useful for you if you are an enthusiast who runs their own nodes.
+The æternity SDK team currently runs the **sdk-testnet**. This testnet represents the latest stable release.
 
 In the previous tutorial we've installed **aecli**. So we can use ```aecli chain``` to interact with the blockchain. You can see additional information for the command here:
 ```
@@ -30,7 +30,7 @@ Commands:
 ```
 
 ### sdk-testnet
-Audience – people using released versions of our SDKs. Most software developers should use this one.
+Audience – people using released versions of our SDKs. Most software developers should use this for testing purposes.
 
 Let's check the Epoch version of sdk-testnet:
 ```
@@ -49,20 +49,7 @@ Pending transactions count______________ 0
 Solutions_______________________________ 0
 Syncing_________________________________ false
 ```
-### sdk-edgenet
-Audience – people developing the SDKs, developers who need the latest features from the develop branch on github. This network is used primarily for development and can be reset without notification.
 
-Epoch version checking:
-```
-aecli chain status -u https://sdk-edgenet.aepps.com
-```
-```
-Epoch node version____________  1.0.0
-```
-
-### uat-testnet
-
-Audience – core developers, miners, people who want to track the bleeding edge. You may not be able to connect to this using our SDKs because it’s a version later than the ones they support.
 ## Before funding
 We are going to use the secure wallet created in the previous tutorial - ```my-ae-wallet```.
 Getting wallet balance: 
@@ -99,16 +86,13 @@ API ERROR: Account not found
 ```
 The account is not found, because the wallet actually has 0 funds and the balance is equal to 0.
 
-Running the above command, but with ```-u https://sdk-testnet.aepps.com``` will result in the same error.
-
 Let's change that!
 ## Getting tokens
-There are two ways of getting tokens. The faucets operated by the SDK team will give you tokens for no effort at all. Alternatively, you can mine your own. The SDK team does not provide tokens for the uat-testnet via a faucet.
-### Faucets
+There are two ways of getting tokens. The faucet operated by the SDK team will give you tokens for no effort at all. Alternatively, you can mine your own.
+### Faucet
 - sdk-testnet - https://faucet.aepps.com/
-- sdk-edgenet - https://edge-faucet.aepps.com/
 
-In the next steps we're going to show you how to get tokens from the faucet for **sdk-testnet**. The same proces could be followed for the **sdk-edgenet**.
+In the next steps we're going to show you how to get tokens from the faucet for **sdk-testnet**.
 ![][faucet_initial_img]
 *<center>Initial dialog</center>*
 
@@ -146,7 +130,7 @@ If you want to use your node to mine, please read the following documentation:
 [Beneficiary Account and Miner Configuration](https://github.com/aeternity/epoch/blob/master/docs/configuration.md#beneficiary-account)
 
 ## Conclusion
-Testnets are an incredibly useful tool in æpps development. They make the process of testing the æternity software much easier by providing safety layers on which to experiment before pushing something to the live network.
+The testnet is an incredibly useful tool in æpps development. It makes the process of testing the æternity software much easier by providing safety layers on which to experiment before pushing something to the live network.
 
 The æternity team will keep this tutorial updated. If you encounter any problems please contact us through the [æternity Forum](https://forum.aeternity.com/c/development).
 

--- a/get-testnet-tokens.md
+++ b/get-testnet-tokens.md
@@ -103,7 +103,7 @@ aecli account address my-ae-wallet
 ```
 The CLI will prompt you to type in your password and will give you the following output:
 ```
-Your address is: ak_maudCMZW7WyPrHFhpJNzjBtNBw62L7jceMyqkXkYVXtVfcDK1
+Address_________________________________ ak_maudCMZW7WyPrHFhpJNzjBtNBw62L7jceMyqkXkYVXtVfcDK1
 ```
 We are placing a request and just few seconds later, our account is topped up:
 ```

--- a/get-testnet-tokens.md
+++ b/get-testnet-tokens.md
@@ -1,6 +1,6 @@
 # TUTORIAL: How to Get Testnet Funds?
 ## Tutorial Overview
-In this tutorial we'll briefly explain the æternity testnet – what they are, what they're used for, and how to get AE tokens from a faucet for the testnet.
+In this tutorial we'll briefly explain the æternity testnet – what it is, what it's used for, and how to get AE tokens from a faucet for the testnet.
 ## Prerequisites
 - Please read our previous tutorial [How to Create an æternity Account With CLI?](account-creation-in-ae-cli.md) in order to better understand the next steps and to follow them.
 ## æternity test network


### PR DESCRIPTION
I'm not sure what's the status of the `sdk-edgenet` and `uat-testnet` and whether or not they're still being maintained. Currently when trying to reach them, I am receiving the following respectively:
```
$ aecli chain status -u https://sdk-edgenet.aepps.com
Request failed with status code 404 undefined
```
```
$ aecli chain status -u https://uat-testnet.aepps.com
getaddrinfo ENOTFOUND uat-testnet.aepps.com uat-testnet.aepps.com:443 undefined
```

Let me know if you'd like me to push another commit to remove them from the tutorial or alternatively to leave them as is for now.

Thanks! ak_25qxcUwYkkYxAhCM7pH8XT5Vow9oowRzERsiYCSZvaU6bTo7Wm

