### PR TITLE
Updating small issues in "TUTORIAL: Deploying Sophia smart contracts with init parameters"

### DIFF
--- a/deploy-with-init-params.md
+++ b/deploy-with-init-params.md
@@ -13,15 +13,12 @@ You have completed [this tutorial](smart-contract-deployment-in-forgae.md) that 
 We would need a local node to compile and deploy on. The easiest option is to spawn one from forgae. Follow the below steps to create a project, initialize the project, and test the project using forgae on your CLI:
 
 ```
-Step 1: $ mkdir forgae-init
-Step 2: $ cd forgae-init
-Step 3: $ forgae init
-Step 4: $ forgae node or docker-compose for docker toolbox users
 mkdir forgae-init
 cd forgae-init
 forgae init
 forgae node
 ```
+Note: For docker toolbox users, you may need to run `docker-compose` instead of `forgae node`
 
 #### Output of `forgae init`:
 
@@ -114,15 +111,15 @@ const Deployer = require('forgae-lib').Deployer;
 const deploy = async (network, privateKey, compiler) => {
     let deployer = new Deployer(network, privateKey, compiler)
 
-	let contract = await deployer.deploy("./contracts/ExampleContract.aes", [42])
+    let contract = await deployer.deploy("./contracts/ExampleContract.aes", [42])
 
-	let encodedSavedNumber = await contract.call('savedNumber')
-	let decodedSavedNumber = await encodedSavedNumber.decode("int")
-	console.log(decodedSavedNumber) // 42
+    let encodedSavedNumber = await contract.call('savedNumber')
+    let decodedSavedNumber = await encodedSavedNumber.decode("int")
+    console.log(decodedSavedNumber) // 42
 };
 
 module.exports = {
-	deploy
+    deploy
 };
 
 ```


### PR DESCRIPTION
- [x] Fixed duplicate setup commands
- [x] Improved code indentation

I didn't try using `docker-compose` separately, but I assume it may be necessary as reported by @GoodnessEzeokafor if one is running certain versions of Windows as opposed to a standard Unix-based instance. I also separated that line so that it's easier to follow during copy & pasting.

ak_25qxcUwYkkYxAhCM7pH8XT5Vow9oowRzERsiYCSZvaU6bTo7Wm
